### PR TITLE
Update winui.lua

### DIFF
--- a/scripts/src/osd/winui.lua
+++ b/scripts/src/osd/winui.lua
@@ -1,3 +1,12 @@
+
+---------------------------------------------------------------------------
+--
+--   winui.lua
+--
+--   Rules for the building for Windows
+--
+---------------------------------------------------------------------------
+
 dofile("modules.lua")
 
 premake.make.linkoptions_after = false;
@@ -81,7 +90,7 @@ newoption {
 	description = "Minimum DirectInput version to support",
 	allowed = {
 		{ "7",  "Support DirectInput 7 or later"  },
-		{ "8",  "Support DirectInput 8 or later" },
+		{ "8",  "Support DirectInput 8 or later"  },
 	},
 }
 
@@ -108,7 +117,7 @@ project ("qtdbg_" .. _OPTIONS["osd"])
 
 project ("osd_" .. _OPTIONS["osd"])
 	uuid (os.uuid("osd_" .. _OPTIONS["osd"]))
-	kind "StaticLib"
+	kind (LIBTYPE)
 
 	dofile("winui_cfg.lua")
 	osdmodulesbuild()
@@ -129,7 +138,7 @@ project ("osd_" .. _OPTIONS["osd"])
 
 	includedirs {
 		MAME_DIR .. "src/emu",
-		MAME_DIR .. "src/devices",
+		MAME_DIR .. "src/devices", -- accessing imagedev from debugger
 		MAME_DIR .. "src/osd",
 		MAME_DIR .. "src/lib",
 		MAME_DIR .. "src/lib/util",
@@ -143,31 +152,56 @@ project ("osd_" .. _OPTIONS["osd"])
 
 	files {
 		MAME_DIR .. "src/osd/modules/render/drawd3d.cpp",
+		MAME_DIR .. "src/osd/modules/render/drawd3d.h",
 		MAME_DIR .. "src/osd/modules/render/d3d/d3d9intf.cpp",
 		MAME_DIR .. "src/osd/modules/render/d3d/d3dhlsl.cpp",
+		MAME_DIR .. "src/osd/modules/render/d3d/d3dcomm.h",
+		MAME_DIR .. "src/osd/modules/render/d3d/d3dhlsl.h",
+		MAME_DIR .. "src/osd/modules/render/d3d/d3dintf.h",
 		MAME_DIR .. "src/osd/modules/render/drawdd.cpp",
 		MAME_DIR .. "src/osd/modules/render/drawgdi.cpp",
 		MAME_DIR .. "src/osd/modules/render/drawnone.cpp",
 		MAME_DIR .. "src/osd/windows/input.cpp",
+		MAME_DIR .. "src/osd/windows/input.h",
 		MAME_DIR .. "src/osd/windows/output.cpp",
+		MAME_DIR .. "src/osd/windows/output.h",
 		MAME_DIR .. "src/osd/windows/video.cpp",
+		MAME_DIR .. "src/osd/windows/video.h",
 		MAME_DIR .. "src/osd/windows/window.cpp",
+		MAME_DIR .. "src/osd/windows/window.h",
+		MAME_DIR .. "src/osd/modules/osdwindow.h",
 --		MAME_DIR .. "src/osd/windows/winmenu.cpp",
 		MAME_DIR .. "src/osd/winui/newui.cpp",
 		MAME_DIR .. "src/osd/windows/winmain.cpp",
+		MAME_DIR .. "src/osd/windows/winmain.h",
+		MAME_DIR .. "src/osd/osdepend.h",
 		MAME_DIR .. "src/osd/modules/debugger/win/consolewininfo.cpp",
+		MAME_DIR .. "src/osd/modules/debugger/win/consolewininfo.h",
 		MAME_DIR .. "src/osd/modules/debugger/win/debugbaseinfo.cpp",
+		MAME_DIR .. "src/osd/modules/debugger/win/debugbaseinfo.h",
 		MAME_DIR .. "src/osd/modules/debugger/win/debugviewinfo.cpp",
+		MAME_DIR .. "src/osd/modules/debugger/win/debugviewinfo.h",
 		MAME_DIR .. "src/osd/modules/debugger/win/debugwininfo.cpp",
+		MAME_DIR .. "src/osd/modules/debugger/win/debugwininfo.h",
 		MAME_DIR .. "src/osd/modules/debugger/win/disasmbasewininfo.cpp",
+		MAME_DIR .. "src/osd/modules/debugger/win/disasmbasewininfo.h",
 		MAME_DIR .. "src/osd/modules/debugger/win/disasmviewinfo.cpp",
+		MAME_DIR .. "src/osd/modules/debugger/win/disasmviewinfo.h",
 		MAME_DIR .. "src/osd/modules/debugger/win/disasmwininfo.cpp",
+		MAME_DIR .. "src/osd/modules/debugger/win/disasmwininfo.h",
 		MAME_DIR .. "src/osd/modules/debugger/win/editwininfo.cpp",
+		MAME_DIR .. "src/osd/modules/debugger/win/editwininfo.h",
 		MAME_DIR .. "src/osd/modules/debugger/win/logwininfo.cpp",
+		MAME_DIR .. "src/osd/modules/debugger/win/logwininfo.h",
 		MAME_DIR .. "src/osd/modules/debugger/win/memoryviewinfo.cpp",
+		MAME_DIR .. "src/osd/modules/debugger/win/memoryviewinfo.h",
 		MAME_DIR .. "src/osd/modules/debugger/win/memorywininfo.cpp",
+		MAME_DIR .. "src/osd/modules/debugger/win/memorywininfo.h",
 		MAME_DIR .. "src/osd/modules/debugger/win/pointswininfo.cpp",
+		MAME_DIR .. "src/osd/modules/debugger/win/pointswininfo.h",
 		MAME_DIR .. "src/osd/modules/debugger/win/uimetrics.cpp",
+		MAME_DIR .. "src/osd/modules/debugger/win/uimetrics.h",
+		MAME_DIR .. "src/osd/modules/debugger/win/debugwin.h",
 		MAME_DIR .. "src/osd/winui/win_options.cpp",
 		MAME_DIR .. "src/osd/winui/mui_util.cpp",
 		MAME_DIR .. "src/osd/winui/directinput.cpp",
@@ -197,19 +231,17 @@ project ("osd_" .. _OPTIONS["osd"])
 		MAME_DIR .. "src/osd/winui/mui_main.cpp",
 	}
 
+
 project ("ocore_" .. _OPTIONS["osd"])
 	uuid (os.uuid("ocore_" .. _OPTIONS["osd"]))
-	kind "StaticLib"
+	kind (LIBTYPE)
 
-	options {
-		"ForceCPP",
-	}
 	removeflags {
-		"SingleOutputDir",	
+		"SingleOutputDir",
 	}
 
 	dofile("windows_cfg.lua")
-	
+
 	includedirs {
 		MAME_DIR .. "src/emu",
 		MAME_DIR .. "src/osd",
@@ -227,20 +259,43 @@ project ("ocore_" .. _OPTIONS["osd"])
 	}
 
 	files {
+		MAME_DIR .. "src/osd/eigccppc.h",
+		MAME_DIR .. "src/osd/eigccx86.h",
+		MAME_DIR .. "src/osd/eivc.h",
+		MAME_DIR .. "src/osd/eivcx86.h",
+		MAME_DIR .. "src/osd/eminline.h",
+		MAME_DIR .. "src/osd/osdcomm.h",
 		MAME_DIR .. "src/osd/osdcore.cpp",
+		MAME_DIR .. "src/osd/osdcore.h",
 		MAME_DIR .. "src/osd/strconv.cpp",
+		MAME_DIR .. "src/osd/strconv.h",
+		MAME_DIR .. "src/osd/windows/main.cpp",
 		MAME_DIR .. "src/osd/windows/windir.cpp",
 		MAME_DIR .. "src/osd/windows/winfile.cpp",
 		MAME_DIR .. "src/osd/modules/sync/sync_windows.cpp",
+		MAME_DIR .. "src/osd/modules/sync/osdsync.h",
 		MAME_DIR .. "src/osd/windows/winutf8.cpp",
+		MAME_DIR .. "src/osd/windows/winutf8.h",
 		MAME_DIR .. "src/osd/windows/winutil.cpp",
+		MAME_DIR .. "src/osd/windows/winutil.h",
+		MAME_DIR .. "src/osd/windows/winfile.h",
 		MAME_DIR .. "src/osd/windows/winclip.cpp",
 		MAME_DIR .. "src/osd/windows/winsocket.cpp",
 		MAME_DIR .. "src/osd/windows/winptty.cpp",
 		MAME_DIR .. "src/osd/modules/osdmodule.cpp",
-		MAME_DIR .. "src/osd/modules/sync/work_osd.cpp",
+		MAME_DIR .. "src/osd/modules/osdmodule.h",
 		MAME_DIR .. "src/osd/modules/lib/osdlib_win32.cpp",
 	}
+
+	if _OPTIONS["NOASM"] == "1" then
+		files {
+			MAME_DIR .. "src/osd/modules/sync/work_mini.cpp",
+		}
+	else
+		files {
+			MAME_DIR .. "src/osd/modules/sync/work_osd.cpp",
+		}
+	end
 
 
 --------------------------------------------------
@@ -252,11 +307,10 @@ if _OPTIONS["with-tools"] then
 		uuid ("061293ca-7290-44ac-b2b5-5913ae8dc9c0")
 		kind "ConsoleApp"
 
-		options {
-			"ForceCPP",
-		}
 
-		targetdir(MAME_DIR)
+		if _OPTIONS["SEPARATE_BIN"]~="1" then 
+			targetdir(MAME_DIR)
+		end
 
 		links {
 			"ocore_" .. _OPTIONS["osd"],
@@ -265,9 +319,8 @@ if _OPTIONS["with-tools"] then
 		includedirs {
 			MAME_DIR .. "src/osd",
 		}
-
+		
 		files {
 			MAME_DIR .. "src/osd/windows/ledutil.cpp",
 		}
 end
-


### PR DESCRIPTION
- Added missing osd/.../*.h header files (since 0.168 in windows.lua). Question: Must we added also the osd/winui/*.h header files?
- Removed unneeded ForceCPP
- Changed winui.lua so it matches more windows.lua
- Note: Using WDiff to compare winui.lua and windows.lua (http://www.csitte.at/wdiff/wdiff150.zip)