### PR TITLE
Setup always DIRECT INPUT 7 for the GUI

### DIFF
--- a/src/osd/winui/directinput.cpp
+++ b/src/osd/winui/directinput.cpp
@@ -81,11 +81,11 @@ BOOL DirectInputInitialize()
 	if (dic == NULL)
 		return FALSE;
 
-	hr = dic(GetModuleHandle(NULL), DIRECTINPUT_VERSION, &di, NULL);
+	hr = dic(GetModuleHandle(NULL), 0x0700, &di, NULL);	// setup DIRECT INPUT 7 for the GUI
 
 	if (FAILED(hr))
 	{
-		hr = dic(GetModuleHandle(NULL), 0x0300, &di, NULL);
+		hr = dic(GetModuleHandle(NULL), 0x0500, &di, NULL);	// if failed, try with version 5
 
 		if (FAILED(hr))
 		{


### PR DESCRIPTION
Regardless of MAME core settings, we can safely setup for the GUI DIRECT INPUT 7. This extends the range of supported joypads for navigate the interface with joystick.