### PR TITLE
Removal usage of WIN_OPTIONS.CPP

### DIFF
--- a/src/osd/winui/game_opts.h
+++ b/src/osd/winui/game_opts.h
@@ -6,7 +6,7 @@
 
 #include "emu.h"
 #include "drivenum.h"
-#include "win_options.h"
+#include "options.h"
 
 class string_iterator
 {
@@ -19,6 +19,7 @@ public:
 	void copy(const char *str)
 	{
 		/* reset the structure */
+		m_index = 0;
 		m_str.clear();
 		m_base = (str != NULL) ? str : "";
 		m_cur = m_base;
@@ -215,7 +216,7 @@ public:
 	}
 
 private:
-	win_options m_info;
+	core_options m_info;
 	int         m_total;
 
 	struct driver_options


### PR DESCRIPTION
After a serious look at the files, It turned out that our WIN_OPTIONS.CPP is in practice a copy of core file OPTIONS.CPP (src\lib\util\options.cpp). A couple of changes allow us to completely remove the copied files from MAMEUI source and live happy. Tested here with MAMEUIFX, it works. Though I suggest you to do some tests on your side. The gamelist should be created and parsed correctly as before. 
Don't forget to update your WINUI.LUA script and remove the entries for win_options.cpp/.h after your verified all is compiling and working ok. Sorry, but compile a full MAMEUI takes over an hour here.